### PR TITLE
Allow passing the halt flag value to the audio message

### DIFF
--- a/OhmSender.cpp
+++ b/OhmSender.cpp
@@ -278,7 +278,7 @@ void OhmSenderDriver::SetAudioFormat(TUint aSampleRate, TUint aBitRate, TUint aC
     iCodecName.Replace(aCodecName);
 }
 
-void OhmSenderDriver::SendAudio(const TByte* aData, TUint aBytes)
+void OhmSenderDriver::SendAudio(const TByte* aData, TUint aBytes, TBool aHalt)
 {
     AutoMutex mutex(iMutex);
     
@@ -303,7 +303,7 @@ void OhmSenderDriver::SendAudio(const TByte* aData, TUint aBytes)
 	}
 
 	OhmMsgAudio& msg = iFactory.CreateAudio(
-		false,  // halt
+		aHalt,  // halt
         iLossless,
 		false,
 		false,

--- a/OhmSender.h
+++ b/OhmSender.h
@@ -29,7 +29,7 @@ class OhmSenderDriver : public IOhmSenderDriver
 public:
     OhmSenderDriver(Environment& aEnv);
     void SetAudioFormat(TUint aSampleRate, TUint aBitRate, TUint aChannels, TUint aBitDepth, TBool aLossless, const Brx& aCodecName);
-    void SendAudio(const TByte* aData, TUint aBytes);
+    void SendAudio(const TByte* aData, TUint aBytes, TBool aHalt = false);
 
 private:    
     // IOhmSenderDriver


### PR DESCRIPTION
Though this repository is considered to be unmaintained, it is still used by some applications.

The current Sender driver interface does not allow to pass the halt flag to the audio message, which is quite unfortunate, as this flag is can be used by the Receivers to detect the end of the audio stream.